### PR TITLE
c2w-net: move some logs to debug level

### DIFF
--- a/cmd/c2w-net/main.go
+++ b/cmd/c2w-net/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -52,8 +54,11 @@ func main() {
 		}
 	}
 	if *debug {
-		fmt.Fprintf(os.Stderr, "port mapping: %+v\n", forwards)
+		log.SetOutput(os.Stderr)
+	} else {
+		log.SetOutput(io.Discard)
 	}
+	log.Printf("port mapping: %+v\n", forwards)
 	config := &gvntypes.Configuration{
 		Debug:             *debug,
 		MTU:               1500,
@@ -76,22 +81,23 @@ func main() {
 	}
 	if *invoke {
 		go func() {
+			fmt.Fprintf(os.Stderr, "waiting for NW initialization\n")
 			var conn net.Conn
 			for i := 0; i < 10; i++ {
 				time.Sleep(1 * time.Second)
-				fmt.Fprintf(os.Stderr, "connecting to NW...\n")
+				log.Printf("connecting to NW...\n")
 				conn, err = net.Dial("tcp", *wasiAddr)
 				if err == nil {
 					break
 				}
-				fmt.Fprintf(os.Stderr, "failed connecting to NW: %v\n", err)
+				log.Printf("failed connecting to NW: %v\n", err)
 			}
 			if conn == nil {
-				panic("failed to connect to vm")
+				log.Fatalf("failed to connect to vm: lasterr=%d", err)
 			}
 			// We register our VM network as a qemu "-netdev socket".
 			if err := vn.AcceptQemu(context.TODO(), conn); err != nil {
-				fmt.Fprintf(os.Stderr, "failed AcceptQemu: %v\n", err)
+				log.Printf("failed AcceptQemu: %v\n", err)
 			}
 		}()
 		var cmd *exec.Cmd
@@ -112,7 +118,7 @@ func main() {
 		http.Handle("/", websocket.Handler(func(ws *websocket.Conn) {
 			ws.PayloadType = websocket.BinaryFrame
 			if err := vn.AcceptQemu(context.TODO(), ws); err != nil {
-				fmt.Fprintf(os.Stderr, "forwarding finished: %v\n", err)
+				log.Printf("forwarding finished: %v\n", err)
 			}
 		}))
 		if err := http.ListenAndServe(socketAddr, nil); err != nil {

--- a/tests/integration/utils/utils.go
+++ b/tests/integration/utils/utils.go
@@ -173,7 +173,7 @@ func RunTestRuntimes(t *testing.T, tests ...TestSpec) {
 				assert.NilError(t, testCmd.Start())
 
 				time.Sleep(3 * time.Second) // wait for container fully up-and-running. TODO: introduce synchronization
-				
+
 				tt.Want(t, envInfo, inW, io.TeeReader(outR, os.Stdout))
 				inW.Close()
 


### PR DESCRIPTION
Currently we get too verbose logs during initialization loop of c2w-net.

```
$ c2w-net --invoke -p localhost:8000:80 /tmp/out/httpd.wasm --net=socket
connecting to NW...
failed connecting to NW: dial tcp 127.0.0.1:1234: connect: connection refused
connecting to NW...
failed connecting to NW: dial tcp 127.0.0.1:1234: connect: connection refused
connecting to NW...
failed connecting to NW: dial tcp 127.0.0.1:1234: connect: connection refused
connecting to NW...
failed connecting to NW: dial tcp 127.0.0.1:1234: connect: connection refused
connecting to NW...
```

So this PR moves some logs to `debug` level and improves the log message:

```
$ c2w-net --invoke -p localhost:8000:80 /tmp/out/httpd.wasm --net=socket
waiting for NW initialization
```