### PR TITLE
docs: add c2w-net command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,43 @@ Options
 - `--help, -h`: show help
 - `--version, -v: `print the version
 
+### c2w-net
+
+Runs the user-space network stack used for networking support in converted WASM images.
+It can connect to a WASI runtime's network socket, listen for browser networking over WebSocket, or invoke a WASI image with `wasmtime`.
+
+Usage:
+
+- `c2w-net [options] socket-address`
+- `c2w-net --listen-ws [options] listen-address`
+- `c2w-net --invoke [options] wasm-file [wasm options] [COMMAND] [ARG...]`
+
+Arguments:
+
+- `socket-address`: TCP address of the WASI runtime network socket.
+- `listen-address`: address for the WebSocket listener, for example `localhost:8888`.
+- `wasm-file [wasm options] [COMMAND] [ARG...]`: WASM image and arguments passed to `wasmtime` when using `--invoke`.
+
+Options:
+
+- `--debug`: Enable debug print.
+- `--enable-tls`: Enable TLS for the WebSocket connection.
+- `--invoke`: Invoke the container with networking support using `wasmtime`.
+- `--listen-ws`: Listen on a WebSocket address specified by `listen-address`.
+- `--mac value`: MAC address assigned to the container (default: `"02:00:00:00:00:01"`).
+- `-p value`: Map a port between host and guest (`host:guest` or `ip:host:guest`). The `--mac` flag must be set correctly.
+- `--wasi-addr value`: IP address used to communicate between WASI and the network stack when using `--invoke` (default: `"127.0.0.1:1234"`).
+- `--wasmtime-cli-13`: Use the old wasmtime CLI syntax for version 13 or earlier.
+- `--ws-cert value`: TLS certificate for the WebSocket connection.
+- `--ws-key value`: TLS key for the WebSocket connection.
+
+Examples:
+
+```
+c2w-net --listen-ws localhost:8888
+c2w-net --invoke -p localhost:8000:80 /tmp/out/httpd.wasm --net=socket
+```
+
 ### Run-time flags for WASM image
 
 You can specify run-time flags to the generated wasm image for configuring the execution (e.g. for changing command to run in the container).


### PR DESCRIPTION
Closes #360.

Summary:
- Adds a c2w-net command reference to README.
- Documents socket, WebSocket listener, and --invoke usage with the current command options.
- Includes examples that match the existing networking docs.

Validation:
- go run ./cmd/c2w-net --help
- go test ./cmd/c2w-net -count=1
- git diff --check origin/main...HEAD